### PR TITLE
Fix 'use strict';

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-'use strcit';
+'use strict';
 
 const assert = require('assert');
 const Transform = require('stream').Transform;


### PR DESCRIPTION
Solve 'SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode'